### PR TITLE
remove usage of slyguy drm base_url

### DIFF
--- a/lib/drmhelper/helper.py
+++ b/lib/drmhelper/helper.py
@@ -22,7 +22,6 @@ class DRMHelper(object):
     """DRM Helper"""
     def __init__(self):
         self.addon = None
-        self.wvcdm_download_base_url = None
         self.wvcdm_download_data = None
 
     def _get_system(self):
@@ -241,7 +240,6 @@ class DRMHelper(object):
     def _set_wvcdm_current_ver_data(self):
         data = requests.get(config.CDM_CURRENT_VERSION_URL).text
         json_data = json.loads(data).get('widevine')
-        self.wvcdm_download_base_url = json_data.get('base_url')
         plat = self._lookup_mjh_plat()
         self.wvcdm_download_data = json_data['platforms'].get(plat)
 
@@ -392,9 +390,8 @@ class DRMHelper(object):
         plat = self._get_platform()
         self._set_wvcdm_current_ver_data()
 
-        url = os.path.join(self.wvcdm_download_base_url,
-                           self.wvcdm_download_data[0].get('src'))
-        filename = url.split('/')[-1]
+        filename = self.wvcdm_download_data[0].get('src')
+        url = os.path.dirname(config.CDM_CURRENT_VERSION_URL) + '/widevine/' + filename
         wv_cdm_fn = self._get_wvcdm_filename()
 
         if not os.path.isdir(cdm_path):


### PR DESCRIPTION
i want to remove the base_url from the json as I just found i had forgot to change it to new domain and it started breaking stuff.
So, I just want to grab the base from the modules.json url and use that

my "matching" commit to slyguy common:
https://github.com/matthuisman/slyguy.addons/commit/d75d933469ea6a6ce7d80fce93c1802bd16edb25

also remove usage of os.path.join as I think that may sometimes do \ instead of /.
(https://stackoverflow.com/questions/50585275/can-i-join-urls-using-os-path-join-in-python-or-is-there-a-better-way)

I have not tested - can you please test before merge
