### PR TITLE
Replace deprecated module pipes.quote with shlex.quote

### DIFF
--- a/lib/drmhelper/helper.py
+++ b/lib/drmhelper/helper.py
@@ -4,7 +4,7 @@ import os
 import platform
 import posixpath
 import tempfile
-from pipes import quote
+from shlex import quote
 
 import future.moves.builtins as builtins
 


### PR DESCRIPTION
As the title suggests, the module `pipes` is no longer available from Python 3.13. This pull request replaces the use of `pipes.quote` with `shlex.quote`, which appears to be the recommended fix.